### PR TITLE
Refactor getScarbLockPath for improved readability

### DIFF
--- a/lib/cache-utils.js
+++ b/lib/cache-utils.js
@@ -67,12 +67,10 @@ export async function getCacheKey(scarbLockPath) {
   return `scarb-cache-${platform}-${fileHash}`.toLowerCase();
 }
 
-async function getScarbLockPath(scarbLockPath) {
-  const lockfilePath = scarbLockPath || "Scarb.lock";
-
-  await fs.access(lockfilePath).catch((_) => {
-    throw new Error("failed to find Scarb.lock");
+async function getScarbLockPath(scarbLockPath = "Scarb.lock") {
+  await fs.access(scarbLockPath).catch(() => {
+    throw new Error("Failed to find Scarb.lock");
   });
-
-  return lockfilePath;
+  
+  return scarbLockPath;
 }


### PR DESCRIPTION
- Set default parameter for scarbLockPath directly in the function signature.
- Removed redundant variable assignment for lockfilePath.
- Enhanced clarity by using scarbLockPath directly in fs.access.